### PR TITLE
fix: handle fetch errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@elevatepartners/promise-xray": "^0.1.0",
         "cli-progress": "^3.11.2",
         "consola": "^2.15.3",
         "isomorphic-fetch": "^3.0.0",
@@ -857,6 +858,11 @@
       "engines": {
         "node": ">=0.1.90"
       }
+    },
+    "node_modules/@elevatepartners/promise-xray": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@elevatepartners/promise-xray/-/promise-xray-0.1.0.tgz",
+      "integrity": "sha512-5vPkV9kR3m0u8Xv7eLTXj/MkDmW0oUfaLGuocYH4OSoH+13ZyEKD42DNLSu5YjsAt+XlGxu7Kk+IhSY5KR3xrg=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -12393,6 +12399,11 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
       "optional": true
+    },
+    "@elevatepartners/promise-xray": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@elevatepartners/promise-xray/-/promise-xray-0.1.0.tgz",
+      "integrity": "sha512-5vPkV9kR3m0u8Xv7eLTXj/MkDmW0oUfaLGuocYH4OSoH+13ZyEKD42DNLSu5YjsAt+XlGxu7Kk+IhSY5KR3xrg=="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "cli-progress": "^3.11.2",
         "consola": "^2.15.3",
         "isomorphic-fetch": "^3.0.0",
-        "promise-xray": "file:../nodejs/promise-xray",
         "yargs": "^17.6.2"
       },
       "bin": {
@@ -33,15 +32,19 @@
       }
     },
     "../nodejs/promise-xray": {
+      "name": "@elevatepartners/promise-xray",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "MIT",
       "devDependencies": {
+        "@tsconfig/node-lts-strictest": "^18.12.1",
         "@types/jest": "^29.2.4",
         "@types/node": "^18.11.10",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
         "eslint": "^8.29.0",
         "jest": "^29.3.1",
+        "semantic-release": "^19.0.5",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.3"
@@ -9782,10 +9785,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/promise-xray": {
-      "resolved": "../nodejs/promise-xray",
-      "link": true
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -18883,20 +18882,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
-    },
-    "promise-xray": {
-      "version": "file:../nodejs/promise-xray",
-      "requires": {
-        "@types/jest": "^29.2.4",
-        "@types/node": "^18.11.10",
-        "@typescript-eslint/eslint-plugin": "^5.45.0",
-        "@typescript-eslint/parser": "^5.45.0",
-        "eslint": "^8.29.0",
-        "jest": "^29.3.1",
-        "ts-jest": "^29.0.3",
-        "ts-node": "^10.9.1",
-        "typescript": "^4.9.3"
-      }
     },
     "prompts": {
       "version": "2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "cli-progress": "^3.11.2",
         "consola": "^2.15.3",
         "isomorphic-fetch": "^3.0.0",
+        "promise-xray": "file:../nodejs/promise-xray",
         "yargs": "^17.6.2"
       },
       "bin": {
@@ -29,6 +30,21 @@
         "ts-jest": "^29.0.3",
         "ts-standard": "^12.0.1",
         "typescript": "^4.8.4"
+      }
+    },
+    "../nodejs/promise-xray": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/jest": "^29.2.4",
+        "@types/node": "^18.11.10",
+        "@typescript-eslint/eslint-plugin": "^5.45.0",
+        "@typescript-eslint/parser": "^5.45.0",
+        "eslint": "^8.29.0",
+        "jest": "^29.3.1",
+        "ts-jest": "^29.0.3",
+        "ts-node": "^10.9.1",
+        "typescript": "^4.9.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -9766,6 +9782,10 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/promise-xray": {
+      "resolved": "../nodejs/promise-xray",
+      "link": true
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -18863,6 +18883,20 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "promise-xray": {
+      "version": "file:../nodejs/promise-xray",
+      "requires": {
+        "@types/jest": "^29.2.4",
+        "@types/node": "^18.11.10",
+        "@typescript-eslint/eslint-plugin": "^5.45.0",
+        "@typescript-eslint/parser": "^5.45.0",
+        "eslint": "^8.29.0",
+        "jest": "^29.3.1",
+        "ts-jest": "^29.0.3",
+        "ts-node": "^10.9.1",
+        "typescript": "^4.9.3"
+      }
     },
     "prompts": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
+    "@elevatepartners/promise-xray": "^0.1.0",
     "cli-progress": "^3.11.2",
     "consola": "^2.15.3",
     "isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cli-progress": "^3.11.2",
     "consola": "^2.15.3",
     "isomorphic-fetch": "^3.0.0",
+    "promise-xray": "file:../nodejs/promise-xray",
     "yargs": "^17.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "cli-progress": "^3.11.2",
     "consola": "^2.15.3",
     "isomorphic-fetch": "^3.0.0",
-    "promise-xray": "file:../nodejs/promise-xray",
     "yargs": "^17.6.2"
   }
 }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,20 +1,9 @@
 import consola from 'consola'
 import { BaseOptions } from './cli/options'
 import { ProgressBar } from './lib/progressBar'
-import { MetricsService, NpmService, ReportService } from './services'
-import { DependencyMetric, Metrics, PackageContents, Versions } from './types'
+import { MetricsService, MetricsGeneratorService, NpmService, ReportService } from './services'
+import { Metrics, PackageContents } from './types'
 import { all } from '@elevatepartners/promise-xray'
-
-const getDependencyMetrics = (currentVersion: string, maxDate: Date) =>
-  (versions?: Versions) => {
-    if (!versions) return
-
-    return MetricsService.calculate({
-      maxDate,
-      version: currentVersion,
-      versions
-    })
-  }
 
 export const generate = async (
   contents: PackageContents,
@@ -49,7 +38,9 @@ export const generate = async (
 
   const promisedMetrics = deps.map((dependency) =>
     NpmService.versions(dependency)
-      .then(getDependencyMetrics(depsVersions[dependency], maxDate))
+      .then(MetricsGeneratorService.dependencyMetrics({
+        currentVersion: depsVersions[dependency], maxDate
+      }))
   )
 
   const rawMetrics = await all(promisedMetrics, bar)

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -3,7 +3,7 @@ import { BaseOptions } from './cli/options'
 import { ProgressBar } from './lib/progressBar'
 import { MetricsService, NpmService, ReportService } from './services'
 import { DependencyMetric, Metrics, PackageContents, Versions } from './types'
-import { scan } from 'promise-xray'
+import { all } from 'promise-xray'
 
 const getDependencyMetrics = (currentVersion: string, maxDate: Date) =>
   (versions?: Versions) => {
@@ -52,7 +52,7 @@ export const generate = async (
       .then(getDependencyMetrics(depsVersions[dependency], maxDate))
   )
 
-  const rawMetrics = await scan(promisedMetrics, bar)
+  const rawMetrics = await all(promisedMetrics, bar)
 
   const metrics = rawMetrics.reduce<Metrics>((acc, dm, idx) => {
     if (dm != null) acc[deps[idx]] = dm

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -47,7 +47,7 @@ export const generate = async (
   // TODO: update to allSettled
   const rawMetrics = await all(metricsTasks, bar)
 
-  const metrics = rawMetrics.reduce<Metrics>(MetricsGeneratorService.metricsReducer(deps), {})
+  const metrics = rawMetrics.reduce<Metrics>(MetricsService.reducer(deps), {})
 
   bar.stop()
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -44,12 +44,10 @@ export const generate = async (
 
   const metricsTasks = MetricsGeneratorService.tasks({ deps, maxDate })
 
+  // TODO: update to allSettled
   const rawMetrics = await all(metricsTasks, bar)
 
-  const metrics = rawMetrics.reduce<Metrics>((acc, dm, idx) => {
-    if (dm != null) acc[_deps[idx]] = dm
-    return acc
-  }, {})
+  const metrics = rawMetrics.reduce<Metrics>(MetricsGeneratorService.metricsReducer(deps), {})
 
   bar.stop()
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -3,7 +3,7 @@ import { BaseOptions } from './cli/options'
 import { ProgressBar } from './lib/progressBar'
 import { MetricsService, NpmService, ReportService } from './services'
 import { DependencyMetric, Metrics, PackageContents, Versions } from './types'
-import { all } from 'promise-xray'
+import { all } from '@elevatepartners/promise-xray'
 
 const getDependencyMetrics = (currentVersion: string, maxDate: Date) =>
   (versions?: Versions) => {

--- a/src/services/MetricsGeneratorService/__tests__/dependencyMetrics.test.ts
+++ b/src/services/MetricsGeneratorService/__tests__/dependencyMetrics.test.ts
@@ -1,0 +1,27 @@
+import { DependencyMetric, Versions } from '../../../types'
+import { dependencyMetrics } from '../dependencyMetrics'
+
+describe('dependencyMetrics', () => {
+  test('produces function that calculates dependency metrics', () => {
+    const maxDate = new Date(2022, 2, 1) // 01 Mar 2022
+    const currentVersion = '0.1.0'
+
+    const metricsCalculator = dependencyMetrics({ currentVersion, maxDate })
+
+    let dm = metricsCalculator()
+    expect(dm).toBeUndefined()
+
+    const versions: Versions = {
+      '0.2.0': new Date(2022, 1, 2), // 02 Feb 2022
+      '0.1.0': new Date(2022, 0, 1) // 01 Jan 2022
+    }
+
+    const expectedDM: DependencyMetric = {
+      days: 27,
+      releasesAvailable: 1
+    }
+
+    dm = metricsCalculator(versions)
+    expect(dm).toEqual(expectedDM)
+  })
+})

--- a/src/services/MetricsGeneratorService/dependencyMetrics.ts
+++ b/src/services/MetricsGeneratorService/dependencyMetrics.ts
@@ -1,0 +1,18 @@
+import { MetricsService } from '../MetricsService'
+import { DependencyMetric, Versions } from '../../types'
+
+type DependencyMetrics = (args: {
+  currentVersion: string
+  maxDate: Date
+}) => (versions?: Versions) => DependencyMetric | undefined
+
+export const dependencyMetrics: DependencyMetrics = ({ currentVersion, maxDate }) =>
+  (versions?: Versions) => {
+    if (versions == null) return
+
+    return MetricsService.calculate({
+      maxDate,
+      version: currentVersion,
+      versions
+    })
+  }

--- a/src/services/MetricsGeneratorService/index.ts
+++ b/src/services/MetricsGeneratorService/index.ts
@@ -1,7 +1,9 @@
 import { dependencyMetrics } from './dependencyMetrics'
+import { metricsReducer } from './metricsReducer'
 import { tasks } from './tasks'
 
 export const MetricsGeneratorService = {
   dependencyMetrics,
+  metricsReducer,
   tasks
 }

--- a/src/services/MetricsGeneratorService/index.ts
+++ b/src/services/MetricsGeneratorService/index.ts
@@ -1,9 +1,7 @@
 import { dependencyMetrics } from './dependencyMetrics'
-import { metricsReducer } from './metricsReducer'
 import { tasks } from './tasks'
 
 export const MetricsGeneratorService = {
   dependencyMetrics,
-  metricsReducer,
   tasks
 }

--- a/src/services/MetricsGeneratorService/index.ts
+++ b/src/services/MetricsGeneratorService/index.ts
@@ -1,5 +1,7 @@
 import { dependencyMetrics } from './dependencyMetrics'
+import { tasks } from './tasks'
 
 export const MetricsGeneratorService = {
-  dependencyMetrics
+  dependencyMetrics,
+  tasks
 }

--- a/src/services/MetricsGeneratorService/index.ts
+++ b/src/services/MetricsGeneratorService/index.ts
@@ -1,7 +1,5 @@
-import { dependencyMetrics } from './dependencyMetrics'
 import { tasks } from './tasks'
 
 export const MetricsGeneratorService = {
-  dependencyMetrics,
   tasks
 }

--- a/src/services/MetricsGeneratorService/index.ts
+++ b/src/services/MetricsGeneratorService/index.ts
@@ -1,0 +1,5 @@
+import { dependencyMetrics } from './dependencyMetrics'
+
+export const MetricsGeneratorService = {
+  dependencyMetrics
+}

--- a/src/services/MetricsGeneratorService/metricsReducer.ts
+++ b/src/services/MetricsGeneratorService/metricsReducer.ts
@@ -1,0 +1,7 @@
+import { Dependency, DependencyMetric, Metrics } from '../../types'
+
+export const metricsReducer = (dependencies: Dependency[]) =>
+  (metrics: Metrics, dm: DependencyMetric | undefined, idx: number) => {
+    if (dm != null) metrics[dependencies[idx].name] = dm
+    return metrics
+  }

--- a/src/services/MetricsGeneratorService/tasks.ts
+++ b/src/services/MetricsGeneratorService/tasks.ts
@@ -1,0 +1,17 @@
+import { dependencyMetrics } from './dependencyMetrics'
+import { NpmService } from '../NpmService'
+import { Dependency, DependencyMetric } from '../../types'
+
+type Tasks = (args: {
+  deps: Dependency[]
+  maxDate: Date
+}) => Array<Promise<DependencyMetric | undefined>>
+
+export const tasks: Tasks = ({ deps, maxDate }) =>
+  // the aim of the following map is to build unresolved promise chain,
+  // the result promise collection will be resolved by the caller
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  deps.map(({ name, version }) =>
+    NpmService.versions(name)
+      .then(dependencyMetrics({ currentVersion: version, maxDate }))
+  )

--- a/src/services/MetricsService/__tests__/calculate.test.ts
+++ b/src/services/MetricsService/__tests__/calculate.test.ts
@@ -1,0 +1,41 @@
+import { DependencyMetric, Versions } from '../../../types'
+import { calculate } from '../calculate'
+
+const maxDate = new Date(2022, 11, 1)
+const versions: Versions = {
+  '2.15.0': new Date(2022, 10, 1),
+  '2.15.1': new Date(2022, 10, 2),
+  '2.15.2': new Date(2022, 10, 3),
+  '2.15.3': new Date(2022, 10, 4)
+}
+
+describe('calculate', () => {
+  test.each([
+    { version: 'file:.../abc/package', versions },
+    { version: '2.16.0', versions },
+    { version: '2.15.2', versions: {} }
+  ])('throws an error when cannot find release date of the current version #$#',
+    ({ version, versions }) => {
+      const error = new Error(`failed to get release date for the version: ${version}`)
+
+      expect(() => calculate({ maxDate, version, versions })).toThrow(error)
+    })
+
+  test('returns up to date when current version is the latest version', () => {
+    const version = '^2.15.3'
+
+    const expected: DependencyMetric = { days: 0, releasesAvailable: 0 }
+    const actual = calculate({ maxDate, version, versions })
+
+    expect(actual).toEqual(expected)
+  })
+
+  test('returns amount of days since the latest version released', () => {
+    const version = '^2.15.1'
+
+    const expected: DependencyMetric = { days: 28, releasesAvailable: 2 }
+    const actual = calculate({ maxDate, version, versions })
+
+    expect(actual).toEqual(expected)
+  })
+})

--- a/src/services/MetricsService/calculate.ts
+++ b/src/services/MetricsService/calculate.ts
@@ -7,20 +7,20 @@ type Calculate = (props: {
   version: string
 }) => DependencyMetric
 
-const upToDate = { days: 0, releasesAvailable: 0 }
+const upToDate: DependencyMetric = { days: 0, releasesAvailable: 0 }
 
 export const calculate: Calculate = ({ maxDate, version, versions }) => {
   const releaseDates = Object.values(versions)
-  const selectedVersion = version.replace(/[^\d.-]/g, '')
-  const released = versions[selectedVersion]
+  const currentVersion = version.replace(/[^\d.-]/g, '')
+  const released = versions[currentVersion]
+
+  if (released == null) throw new Error(`failed to get release date for the version: ${version}`)
 
   const latestReleases = releaseDates
-    .filter(releaseDate => {
-      return (
-        releaseDate.getTime() > released.getTime() &&
-        releaseDate.getTime() <= maxDate.getTime()
-      )
-    })
+    .filter(releaseDate =>
+      releaseDate.getTime() > released.getTime() &&
+      releaseDate.getTime() <= maxDate.getTime()
+    )
     .sort((a: Date, b: Date) => a.getTime() - b.getTime())
 
   if (latestReleases.length === 0) return upToDate

--- a/src/services/MetricsService/index.ts
+++ b/src/services/MetricsService/index.ts
@@ -1,7 +1,9 @@
 import { calculate } from './calculate'
+import { reducer } from './reducer'
 import { summary } from './summary'
 
 export const MetricsService = {
   calculate,
+  reducer,
   summary
 }

--- a/src/services/MetricsService/reducer.ts
+++ b/src/services/MetricsService/reducer.ts
@@ -1,6 +1,6 @@
 import { Dependency, DependencyMetric, Metrics } from '../../types'
 
-export const metricsReducer = (dependencies: Dependency[]) =>
+export const reducer = (dependencies: Dependency[]) =>
   (metrics: Metrics, dm: DependencyMetric | undefined, idx: number) => {
     if (dm != null) metrics[dependencies[idx].name] = dm
     return metrics

--- a/src/services/NpmService/versions.ts
+++ b/src/services/NpmService/versions.ts
@@ -1,18 +1,13 @@
-import consola from 'consola'
 import fetch from 'isomorphic-fetch'
 import { extractVersions } from './extractVersions'
 import { Versions } from '../../types'
 
-export const versions = async (dependency: string): Promise<Versions | undefined> => {
+export const versions = async (dependency: string): Promise<Versions> => {
   const url = `https://registry.npmjs.org/${dependency}`
 
-  try {
-    const response = await fetch(url)
-    const { time } = await response.json()
-    const { created, modified, ...versions } = time
+  const response = await fetch(url)
+  const { time } = await response.json()
+  const { created, modified, ...versions } = time
 
-    return extractVersions(versions)
-  } catch (error) {
-    consola.error(error)
-  }
+  return extractVersions(versions)
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,5 @@
 export { LoadService } from './LoadService'
 export { MetricsService } from './MetricsService'
+export { MetricsGeneratorService } from './MetricsGeneratorService'
 export { NpmService } from './NpmService'
 export { ReportService } from './ReportService'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,10 @@
+export interface Dependency {
+  /** dependency name */
+  name: string
+  /** dependency current version */
+  version: string
+}
+
 export interface DependencyMetric {
   /** number of days since the next version was released */
   days: number


### PR DESCRIPTION
## Description

## Related issues

- Issue #62 

## Changes

- Using [promise-xray](https://github.com/ElevatePartners/promise-xray) to concurrently download dependencies information from NPM
- Handling Promise exceptions with Promise.allSettled
- Some of the generator functionality moved to MetricsService and newly created MetricsGeneratorService
